### PR TITLE
Remove unnecessary steps in build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM scratch
 ADD webby /
 EXPOSE 8080
 CMD ["/webby"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM debian:jessie
 ADD webby /
 EXPOSE 8080
-ENTRYPOINT ["/webby"]
+CMD ["/webby"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,5 @@ node {
   def tag = "${name}:${version}"
   sh "docker tag -f ${name} ${tag}"
   sh "docker push ${tag}"
-  sh "docker push ${name}"
 }
 


### PR DESCRIPTION
I removed logic that is only applicable for our Java apps. Also I pinned the version numbers to avoid problems in the future. 

Lastly, the scratch image was not enough to run webby because it needs some base root fs from the OS. `debian:jessie` works, it is used by the majority of the docker images we see including the `golang` image used to compile webby.